### PR TITLE
add Mexico actor

### DIFF
--- a/covid_api_list.json
+++ b/covid_api_list.json
@@ -652,5 +652,19 @@
             "frequency": "5 mins"
         },
         "actorPage": "/dtrungtin/covid-vi"
+    },
+    {
+        "title": "Mexico",
+        "description": "Gets the number of infected people and deaths by COVID-19 in Mexico per state",
+        "dataSource": "https://coronavirus.gob.mx/datos/",
+        "latestApi": {
+            "url": "https://api.apify.com/v2/key-value-stores/vpfkeiYLXPIDIea2T/records/LATEST?disableRedirect=true",
+            "frequency": "5 mins"
+        },
+        "historyApi": {
+            "url": "https://api.apify.com/v2/datasets/4efvuMEdxdQPCreW7/items?format=json&clean=1",
+            "frequency": "5 mins"
+        },
+        "actorPage": "/puorc/mexico-covid19"
     }
 ]


### PR DESCRIPTION
Add Mexico COVID-19 actor. 
Data source is https://coronavirus.gob.mx/datos/. 
I skipped the excel file because it is not editable.

