### PR TITLE
Fix China source data URL

### DIFF
--- a/covid_api_list.json
+++ b/covid_api_list.json
@@ -124,7 +124,7 @@
     {
         "title": "China",
         "description": "Actor gets the actual number of current confirmed, confirmed, suspected, cured and deceased people by COVID-19 in China.",
-        "dataSource": "https://github.com/BlankerL/DXY-COVID-19-Data/blob/master/json/DXYOverall.json",
+        "dataSource": "https://www.worldometers.info/coronavirus/",
         "latestApi": {
             "url": "https://api.apify.com/v2/key-value-stores/x4iHxk7TVGI7UxFv6/records/LATEST?disableRedirect=true",
             "frequency": "5 mins"


### PR DESCRIPTION
The old data source URL is broken, we're loading data from worldometer now.